### PR TITLE
Fix: add terraform ignore so lambdas aren't recreated every apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Furthermore this module supports:
 The module can be used for all [runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) supported by AWS Lambda (defaults to `go1.x`).
 
 In general configure the Lambda function with all required variables and add an (optional) event source (see [variables.tf](https://github.com/spring-media/terraform-aws-lambda/blob/master/variables.tf) for all available options).
+The function is configured to ignore any changes to the function code so that it can be updated as part of your deployment process.
 
 ```
 provider "aws" {

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -26,6 +26,19 @@ resource "aws_lambda_function" "lambda" {
       subnet_ids         = vpc_config.value.subnet_ids
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      filename,
+      s3_bucket,
+      s3_key,
+      s3_object_version,
+      source_code_hash,
+      version,
+      qualified_arn,
+      last_modified,
+    ]
+  }
 }
 
 data "aws_iam_policy_document" "assume_role_policy" {


### PR DESCRIPTION
Update the module so that terraform ignores changes to the lambda's source, to prevent terraform from constantly wanting to recreate.

Taken from https://github.com/RedVentures/terraform-aws-lambda-function

Tested locally by updating the module used by Sage mortgage-pos.