### PR TITLE
[FP-914] Ignore (unused) redrive_policy in SNS subscription lifecycle

### DIFF
--- a/modules/event/sns/main.tf
+++ b/modules/event/sns/main.tf
@@ -12,4 +12,11 @@ resource "aws_sns_topic_subscription" "subscription" {
   endpoint  = var.endpoint
   protocol  = "lambda"
   topic_arn = var.topic_arn
+
+  # Note: redrive policy is safe to ignore here because it's unused.
+  # This only prevents subscriptions created _outside_ of module from
+  # having _their_ redrive policy overwritten by this module.
+  lifecycle {
+    ignore_changes = [redrive_policy]
+  }
 }


### PR DESCRIPTION
Ref. [[Assist] Sage's redrive policy is removed and re-added on TF apply](https://redventures.atlassian.net/browse/FP-914)
# Welcome to my Ted Talk.

### Why
* Currently topic subscriptions requiring a redrive policy are created alongside the app terraform, because redrive policy is not implemented in this module (or the module it was forked from - I checked).
* This module _still_ creates the subscriptions, however, which causes it to _remove_ the redrive policy from the resource that actually created it.
### Confused? Me too, here's some terraform:
* Pay close attention: These are the _same_ resource (note the id/arn), and they live in the state file in _two different locations_.
#### Exhibit A
```
$ terraform state show 'module.velocify.module.event-sns.aws_sns_topic_subscription.subscription[0]'
# module.velocify.module.event-sns.aws_sns_topic_subscription.subscription[0]:
resource "aws_sns_topic_subscription" "subscription" {
    arn                             = "arn:aws:sns:us-east-1:446051487243:qa-interest-event:9fefb62f-a378-42e4-a44d-b750675ac167"
    confirmation_timeout_in_minutes = 1
    confirmation_was_authenticated  = true
    endpoint                        = "arn:aws:lambda:us-east-1:446051487243:function:qa-velocify"
    endpoint_auto_confirms          = false
    id                              = "arn:aws:sns:us-east-1:446051487243:qa-interest-event:9fefb62f-a378-42e4-a44d-b750675ac167"
    owner_id                        = "446051487243"
    pending_confirmation            = false
    protocol                        = "lambda"
    raw_message_delivery            = false
    topic_arn                       = "arn:aws:sns:us-east-1:446051487243:qa-interest-event"
}
```
#### Exhibit B
```
$ terraform state show aws_sns_topic_subscription.invoke_with_sns
# aws_sns_topic_subscription.invoke_with_sns:
resource "aws_sns_topic_subscription" "invoke_with_sns" {
    arn                             = "arn:aws:sns:us-east-1:446051487243:qa-interest-event:9fefb62f-a378-42e4-a44d-b750675ac167"
    confirmation_timeout_in_minutes = 1
    confirmation_was_authenticated  = true
    endpoint                        = "arn:aws:lambda:us-east-1:446051487243:function:qa-velocify"
    endpoint_auto_confirms          = false
    id                              = "arn:aws:sns:us-east-1:446051487243:qa-interest-event:9fefb62f-a378-42e4-a44d-b750675ac167"
    owner_id                        = "446051487243"
    pending_confirmation            = false
    protocol                        = "lambda"
    raw_message_delivery            = false
    redrive_policy                  = jsonencode(
        {
            deadLetterTargetArn = "arn:aws:sqs:us-east-1:446051487243:qa-dead-letter"
        }
    )
    topic_arn                       = "arn:aws:sns:us-east-1:446051487243:qa-interest-event"
}
```
### What does this PR do?
* This adds `redrive_policy` to a list of _ignored_ changes in the sns submodule. The submodule will still function the same because `redrive_policy` has never actually been passed into it, so it's never actually been there, so it's always been _implicitly_ ignored anyway.
* This allows application infra to declare ad-hoc subscriptions _with_ a redrive policy and prevents _this_ submodule from destroying that policy. Basically it doesn't know that it's there.