### PR TITLE
fix(provider): remove version constraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,6 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=4.0"
     }
   }
 }


### PR DESCRIPTION
It's not best practice to version constrain a module, and should be handled at the workspace level. As is, the constraint will prevent the use of the latest runtime versions.