### PR TITLE
feat(lambda): upgrade lambda-function module to v5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "lambda" {
   source                         = "app.terraform.io/bankrate/lambda-function/aws"
-  version                        = "~> 5.0"
+  version                        = "~> 5.0" # Minmum version to fix aws_subnet_ids issue
   handler                        = var.handler
   publish                        = var.publish
   reserved_concurrent_executions = var.reserved_concurrent_executions

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "lambda" {
   source                         = "app.terraform.io/bankrate/lambda-function/aws"
-  version                        = "~> 4.0.0"
+  version                        = "~> 5.0"
   handler                        = var.handler
   publish                        = var.publish
   reserved_concurrent_executions = var.reserved_concurrent_executions


### PR DESCRIPTION
Upgrade the lambda-function module to version 5, which fixes the `aws_subnet_ids` deprecation issue without going to a newer version, which may introduce other issues. 

Error in a referring repo running the latest 4.x AWS provider with the latest version of this module.
![image](https://github.com/bankrate/terraform-aws-lambda/assets/50380700/ca45d228-9394-44c4-b0bf-282004b3bd97)

Avoiding unnecessary changes since the module tests are broken, which is because the necessary org secrets are not available to this repo. This seems to be because this repo is public and cannot be made private because it was forked from a public repo, which would be time consuming to fix.

Ticket: https://redventures.atlassian.net/browse/FP-3902