### PR TITLE
feat(lambda): add architecture support

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 module "lambda" {
   source                         = "app.terraform.io/bankrate/lambda-function/aws"
-  version                        = "~> 4.0.0"
+  version                        = "~> 5.0" # Minmum version to fix aws_subnet_ids issue
+  architecture                   = var.cpu_architecture
   handler                        = var.handler
   publish                        = var.publish
   reserved_concurrent_executions = var.reserved_concurrent_executions

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,12 @@ variable architecture {
   }
 }
 
+variable cpu_architecture {
+  description = "(Optional) Instruction set architecture for your Lambda function. Valid values are 'x86_64' and 'arm64'. Default is 'x86_64'."
+  type        = string
+  default     = "x86_64"
+}
+
 variable "event_trigger_type" {
   default     = "dynamodb"
   description = ""


### PR DESCRIPTION
Add support for the lambda-function module's "architecture" input. This parent module already has an architecture variable that controls trigger related infrastructure, so adding this as "cpu_architecture." Since this is an optional variable with a default value that matches existing defaults, this is a non-breaking change. Missed this on my last update (when I published version 9.0.0).

Not worried about the failing checks since these are just tests and are only failing due to missing secrets. Version 9.0.0 works fine, and this is a very simple, non-breaking change. No semantic release on this repo, so will manually release this change as 9.1.0.

Ticket: [FP-3905](https://redventures.atlassian.net/browse/FP-3905)

[FP-3905]: https://redventures.atlassian.net/browse/FP-3905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ